### PR TITLE
Fix ContentRootDirectory path on Linux

### DIFF
--- a/src/DevilDaggersInfo.Tools/InternalResources.cs
+++ b/src/DevilDaggersInfo.Tools/InternalResources.cs
@@ -35,7 +35,11 @@ public record InternalResources(
 	public static InternalResources Create()
 	{
 #if DEBUG
+		#if WINDOWS
 		const string? ddInfoToolsContentRootDirectory = @"..\..\..\Content";
+		#elif LINUX
+		const string? ddInfoToolsContentRootDirectory = @"./src/DevilDaggersInfo.Tools/Content/";
+		#endif
 #else
 		const string? ddInfoToolsContentRootDirectory = null;
 #endif


### PR DESCRIPTION
The current value (@"..\\..\\..\Content") causes this runtime exception on Linux:
> Unhandled exception. System.InvalidOperationException: The generated content file is missing. Make sure to build in DEBUG mode or copy the file generated in DEBUG mode to the RELEASE output.
>    at DevilDaggersInfo.Tools.Engine.Content.DecompiledContentFile.Create(String contentRootDirectory, String contentFilePath) in ~/ddinfo-tools/src/DevilDaggersInfo.Tools.Engine.Content/DecompiledContentFile.cs:line 23
>    at DevilDaggersInfo.Tools.InternalResources.Create() in ~/ddinfo-tools/src/DevilDaggersInfo.Tools/InternalResources.cs:line 42
>    at DevilDaggersInfo.Tools.Application..ctor(ImGuiController imGuiController) in ~/ddinfo-tools/src/DevilDaggersInfo.Tools/Application.cs:line 30
>    at Program.<Main>$(String[] args) in ~/ddinfo-tools/src/DevilDaggersInfo.Tools/Program.cs:line 52