### PR TITLE
Implement memory reading on linux to fix splits

### DIFF
--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/Linux/LinuxMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/Linux/LinuxMemoryService.cs
@@ -1,8 +1,9 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace DevilDaggersInfo.Tools.NativeInterface.Services.Linux;
 
-internal sealed class LinuxMemoryService : INativeMemoryService
+internal sealed partial class LinuxMemoryService : INativeMemoryService
 {
 	public void WriteMemory(Process process, long address, byte[] bytes, int offset, int size)
 	{
@@ -11,8 +12,33 @@ internal sealed class LinuxMemoryService : INativeMemoryService
 
 	public void ReadMemory(Process process, long address, byte[] bytes, int offset, int size)
 	{
-		// TODO: Implement.
+		unsafe
+		{
+			fixed (byte* localBase = &bytes[offset])
+			{
+				IoVec local = new() { Base = localBase, Len = (nuint)size };
+				IoVec remote = new() { Base = (byte*)address, Len = (nuint)size };
+				ProcessVmReadv(process.Id, &local, 1, &remote, 1, 0);
+			}
+		}
 	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private unsafe struct IoVec
+	{
+		public byte* Base;
+		public nuint Len;
+	}
+
+	// Read memory using linux syscall, this seems to have best cross distro support without having to tinker with OS settings
+	[LibraryImport("libc", EntryPoint = "process_vm_readv", SetLastError = true)]
+	private static unsafe partial long ProcessVmReadv(
+		int pid,
+		IoVec* localIov,
+		ulong liovcnt,
+		IoVec* remoteIov,
+		ulong riovcnt,
+		ulong flags);
 
 	public Process? GetDevilDaggersProcess()
 	{

--- a/src/DevilDaggersInfo.Tools/Ui/Main/MainWindow.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/Main/MainWindow.cs
@@ -260,7 +260,7 @@ internal sealed class MainWindow(ResourceManager resourceManager, UiLayoutManage
 
 			Save templates to quickly load your desired practice settings.
 
-			View live data from the current run (Windows only for now):
+			View live data from the current run:
 			- Splits
 			- Homing usage
 			- Gem collection


### PR DESCRIPTION
Use linux kernel syscall to read memory from DD process to fix the homing/gem splits in Practice.

Tested on Arch with kernel `7.1.5-arch1-2`:
<img width="510" height="912" alt="Screenshot_20260805_141641" src="https://github.com/user-attachments/assets/041defec-6e65-4f77-affa-551043dd96dc" />

Tested on Fedora 44 with kernel `7.1.6-201.fc44.x86_64` (Virutal Machine):
<img width="1734" height="984" alt="fedora-test" src="https://github.com/user-attachments/assets/13a70582-2a7c-4223-bc9b-ae2ebf82f4a4" />