### PR TITLE
Stop churning and orphaning OpenGL objects

### DIFF
--- a/src/DevilDaggersInfo.Tools.Engine/Shader.cs
+++ b/src/DevilDaggersInfo.Tools.Engine/Shader.cs
@@ -2,9 +2,11 @@ using Silk.NET.OpenGL;
 
 namespace DevilDaggersInfo.Tools.Engine;
 
-public sealed class Shader(GL gl, uint id)
+public sealed class Shader(GL gl, uint id) : IDisposable
 {
 	private readonly Dictionary<string, int> _uniformLocations = new();
+
+	private bool _disposed;
 
 	public uint Id { get; } = id;
 
@@ -17,5 +19,15 @@ public sealed class Shader(GL gl, uint id)
 		_uniformLocations.Add(name, location);
 
 		return location;
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+			return;
+
+		_disposed = true;
+
+		gl.DeleteProgram(Id);
 	}
 }

--- a/src/DevilDaggersInfo.Tools/FramebufferData.cs
+++ b/src/DevilDaggersInfo.Tools/FramebufferData.cs
@@ -11,6 +11,8 @@ internal unsafe class FramebufferData(GL gl)
 	public int Width { get; private set; }
 	public int Height { get; private set; }
 
+	private uint DepthRenderbuffer { get; set; }
+
 	public void ResizeIfNecessary(int width, int height)
 	{
 		// ImGui ignores size constraints for docked windows, so callers deriving the framebuffer size by subtracting
@@ -28,12 +30,16 @@ internal unsafe class FramebufferData(GL gl)
 		Width = width;
 		Height = height;
 
-		// Delete previous data.
+		// Delete previous data. The framebuffer goes first so that deleting its attachments below releases their storage
+		// straight away rather than leaving it held by a container that is about to be destroyed anyway.
 		if (Framebuffer != 0)
 			gl.DeleteFramebuffer(Framebuffer);
 
 		if (TextureHandle != 0)
 			gl.DeleteTexture(TextureHandle);
+
+		if (DepthRenderbuffer != 0)
+			gl.DeleteRenderbuffer(DepthRenderbuffer);
 
 		// Create new data.
 		Framebuffer = gl.GenFramebuffer();
@@ -46,17 +52,20 @@ internal unsafe class FramebufferData(GL gl)
 		gl.TexParameterI(TextureTarget.Texture2D, GLEnum.TextureMagFilter, (int)GLEnum.Linear);
 		gl.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, TextureHandle, 0);
 
-		uint rbo = gl.GenRenderbuffer();
-		gl.BindRenderbuffer(RenderbufferTarget.Renderbuffer, rbo);
+		// The handle is kept so this renderbuffer can be deleted on the next resize. Deleting it here while it is attached
+		// happens to be legal, because an unbound framebuffer's attachment keeps the storage alive, but it discards the
+		// only way to ever free it explicitly and leaves the correctness resting on the unbind ordering.
+		DepthRenderbuffer = gl.GenRenderbuffer();
+		gl.BindRenderbuffer(RenderbufferTarget.Renderbuffer, DepthRenderbuffer);
 
 		gl.RenderbufferStorage(RenderbufferTarget.Renderbuffer, InternalFormat.DepthComponent24, (uint)Width, (uint)Height);
-		gl.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, rbo);
+		gl.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, DepthRenderbuffer);
 
 		if (gl.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != GLEnum.FramebufferComplete)
 			Root.Log.Warning("Framebuffer is not complete.");
 
+		gl.BindRenderbuffer(RenderbufferTarget.Renderbuffer, 0);
 		gl.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
-		gl.DeleteRenderbuffer(rbo);
 	}
 
 	public void RenderArena(bool activateMouse, bool activateKeyboard, float delta, ArenaScene arenaScene, ArenaRenderer arenaRenderer)

--- a/src/DevilDaggersInfo.Tools/Ui/ImGuiController.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/ImGuiController.cs
@@ -47,7 +47,7 @@ internal sealed class ImGuiController
 
 	private readonly uint _vbo;
 	private readonly uint _ebo;
-	private uint _vao;
+	private readonly uint _vao;
 
 	private readonly GL _gl;
 	private readonly GlfwInput _glfwInput;
@@ -61,7 +61,7 @@ internal sealed class ImGuiController
 	private int _framebufferWidth;
 	private int _framebufferHeight;
 
-	public ImGuiController(GL gl, GlfwInput glfwInput, ShaderLoader shaderLoader, int windowWidth, int windowHeight)
+	public unsafe ImGuiController(GL gl, GlfwInput glfwInput, ShaderLoader shaderLoader, int windowWidth, int windowHeight)
 	{
 		_gl = gl;
 		_glfwInput = glfwInput;
@@ -80,6 +80,21 @@ internal sealed class ImGuiController
 
 		_vbo = _gl.GenBuffer();
 		_ebo = _gl.GenBuffer();
+
+		// Create the VAO once and record the vertex layout into it. The attribute pointers capture _vbo (bound here) as
+		// their source, and the element buffer binding is VAO state, so both are restored by a single BindVertexArray at
+		// render time. Previously this was regenerated and deleted every frame, churning a GL object per frame.
+		_vao = _gl.GenVertexArray();
+		_gl.BindVertexArray(_vao);
+		_gl.BindBuffer(GLEnum.ArrayBuffer, _vbo);
+		_gl.BindBuffer(GLEnum.ElementArrayBuffer, _ebo);
+		_gl.EnableVertexAttribArray(0);
+		_gl.EnableVertexAttribArray(1);
+		_gl.EnableVertexAttribArray(2);
+		_gl.VertexAttribPointer(0, 2, GLEnum.Float, false, (uint)sizeof(ImDrawVert), (void*)0);
+		_gl.VertexAttribPointer(1, 2, GLEnum.Float, false, (uint)sizeof(ImDrawVert), (void*)8);
+		_gl.VertexAttribPointer(2, 4, GLEnum.UnsignedByte, true, (uint)sizeof(ImDrawVert), (void*)16);
+		_gl.BindVertexArray(0);
 
 		_shaderId = shaderLoader.Load(_vertexShader, _fragmentShader);
 		_projectionMatrixLocation = _gl.GetUniformLocation(_shaderId, "projectionMatrix");
@@ -210,19 +225,11 @@ internal sealed class ImGuiController
 
 		_gl.BindSampler(0, 0);
 
-		_vao = _gl.GenVertexArray();
+		// Bind the VAO built once in the constructor. _vbo still needs an explicit ArrayBuffer binding because the
+		// glBufferData calls in RenderImDrawData target the ArrayBuffer binding point, which is not VAO state; the element
+		// buffer is restored from the VAO.
 		_gl.BindVertexArray(_vao);
-
 		_gl.BindBuffer(GLEnum.ArrayBuffer, _vbo);
-		_gl.BindBuffer(GLEnum.ElementArrayBuffer, _ebo);
-
-		_gl.EnableVertexAttribArray(0);
-		_gl.EnableVertexAttribArray(1);
-		_gl.EnableVertexAttribArray(2);
-
-		_gl.VertexAttribPointer(0, 2, GLEnum.Float, false, (uint)sizeof(ImDrawVert), (void*)0);
-		_gl.VertexAttribPointer(1, 2, GLEnum.Float, false, (uint)sizeof(ImDrawVert), (void*)8);
-		_gl.VertexAttribPointer(2, 4, GLEnum.UnsignedByte, true, (uint)sizeof(ImDrawVert), (void*)16);
 	}
 
 	private unsafe void RenderImDrawData(ImDrawDataPtr drawDataPtr)
@@ -265,10 +272,6 @@ internal sealed class ImGuiController
 				_gl.DrawElementsBaseVertex(GLEnum.Triangles, cmdPtr.ElemCount, GLEnum.UnsignedShort, (void*)(cmdPtr.IdxOffset * sizeof(ushort)), (int)cmdPtr.VtxOffset);
 			}
 		}
-
-		// Destroy the temporary VAO.
-		_gl.DeleteVertexArray(_vao);
-		_vao = 0;
 
 		// Restore scissors.
 		_gl.Disable(EnableCap.ScissorTest);


### PR DESCRIPTION
Follow-up to the arena rendering refactor, covering the remaining cases behind issue #133.

Verified on NVIDIA with no GL debug messages: the ImGui UI renders correctly (which exercises the shared vertex layout heavily), and the 3D editor still renders correctly across seven window resizes, exercising the renderbuffer delete-and-recreate path.