### PR TITLE
Fix abort() when hovering a Run Analysis graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed the splits table in the practice tool corrupting the colors of the UI rendered after it.
+- Fixed the app crashing when hovering a graph in the practice tool's run analysis.
 - Fixed 3D meshes and textures not being reloaded when the Devil Daggers installation directory changes, which could render the dagger, skull and hand using data from the previously loaded installation.
 - Fixed tile hitboxes hiding each other instead of blending, in the 3D views.
 - Fixed the 3D views breaking when their window is made very small.

--- a/src/DevilDaggersInfo.Tools/Ui/Practice/RunAnalysis/GraphsChild.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/Practice/RunAnalysis/GraphsChild.cs
@@ -240,12 +240,15 @@ internal sealed class GraphsChild(FontService fontService)
 		float posX = ImGui.GetCursorPosX();
 
 		ImGui.TextColored(textColor, textLeft);
-		ImGui.SameLine();
 
 		float textWidth = ImGui.CalcTextSize(textRight).X;
 
-		ImGui.SetCursorPosX(posX + 160 - textWidth);
+		// Right-align through SameLine's offset rather than SetCursorPosX. The previous form ended on a bare
+		// SetCursorPosX with no item submitted after it, and Dear ImGui 1.92 asserts on exactly that inside
+		// EndTooltip: it cannot tell whether the tooltip should grow to cover a position nothing was drawn at.
+		// The assert calls abort(), so hovering a Run Analysis graph killed the process outright.
+		// The trailing reset was redundant - Text() already returns the cursor to the start of the next line.
+		ImGui.SameLine(posX + 160 - textWidth);
 		ImGui.Text(textRight);
-		ImGui.SetCursorPosX(posX);
 	}
 }


### PR DESCRIPTION
Hovering a graph in the practice tool's Run Analysis aborts the process.

`GraphsChild.AddTooltipText` right-aligns its second column by moving the cursor, drawing the text, then moving the cursor back — ending on a bare `SetCursorPosX` with no item submitted after it. Dear ImGui 1.92 asserts on exactly that inside `EndTooltip`: it cannot tell whether the tooltip should grow to cover a position where nothing was drawn. `IM_ASSERT` calls `abort()`, so the process dies outright rather than misdrawing.

The fix right-aligns through `SameLine`'s offset argument instead, which never leaves a dangling cursor move. The trailing reset was redundant — `Text()` already returns the cursor to the start of the next line.

## Where it came from

The validation that catches this arrived with 156fd51, the ImGui.NET → Hexa.NET.ImGui migration (Dear ImGui 1.91 → 1.92). The call pattern predates it and was harmless under 1.91.

This is shared UI with no `#if` near it, so it reproduces identically on Windows and Linux.

## Scope

I audited every other `ImGui.SetCursorPos*` site under `Ui/`. Each is immediately followed by an item submission; this was the only occurrence.

## Verification

`upstream/main` does not build on macOS — no platform arm is defined for it, which is what #159 addresses — so I verified this change on a branch that does: 0 errors, 107 warnings (all pre-existing), and hovering a Run Analysis graph no longer aborts.

The change itself is three lines in one method and is platform-independent, so it should be reproducible on Windows or Linux by hovering any graph in Run Analysis on current `main`.
