### PR TITLE
Add macOS (arm64) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,6 @@ __pycache__/
 appsettings.json
 appsettings.Development.json
 encryption.ini
+
+# macOS Finder metadata
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for reading game memory on Linux, which enables live run data (splits, homing usage, gem collection) in the practice tool.
 - Added support for writing game memory on Linux, which enables replay playback from the replay editor and the custom leaderboards.
+- Added macOS (arm64) support, buildable from source. Reading and writing game memory requires launching with `sudo`, since macOS restricts access to another process's memory to root; the practice tool, replay reading and replay injection say so when it is missing, and every other feature works without it. See `MACOS.md`.
 
 ### Fixed
 

--- a/MACOS.md
+++ b/MACOS.md
@@ -1,0 +1,159 @@
+# macOS (arm64)
+
+This document covers what is different about the macOS build. Everything not mentioned here
+behaves as it does on Windows and Linux.
+
+macOS support is **source-only**: there is no published macOS artifact and CI does not build
+one. `.github/workflows/release.yml` is untouched by this port.
+
+## Contents
+
+- [Building and running](#building-and-running)
+- [The `sudo` requirement](#the-sudo-requirement)
+- [Where the game lives](#where-the-game-lives)
+- [Finding the ddstats block](#finding-the-ddstats-block)
+- [OpenGL differences](#opengl-differences)
+- [What is not supported](#what-is-not-supported)
+
+## Building and running
+
+```bash
+dotnet build src/DevilDaggersInfo.Tools.Engine/DevilDaggersInfo.Tools.Engine.csproj
+dotnet build src/DevilDaggersInfo.Tools/DevilDaggersInfo.Tools.csproj
+dotnet run  --project src/DevilDaggersInfo.Tools/DevilDaggersInfo.Tools.csproj
+```
+
+Build the two projects individually rather than the solution. In `Debug` the platform
+constant follows the build host, so a macOS host defines `OSX` and the right arm compiles.
+In `Release` it follows `RuntimeIdentifier`, which is unset for a plain solution build — so
+none of `WINDOWS`, `LINUX` or `OSX` is defined, no platform arm compiles, and the build
+fails on the platform-specific files rather than on anything macOS-specific. Pass
+`-r osx-arm64` if you want a Release build.
+
+Only `osx-arm64` is wired up. An Intel Mac would need `osx-x64` adding to the `Choose`
+block in `DevilDaggersInfo.Tools.csproj` and has not been tested.
+
+## The `sudo` requirement
+
+**Reading another process's memory on macOS requires root.** There is no entitlement or
+per-user permission that substitutes for it on a locally built, unsigned binary: `task_for_pid`
+against a process you do not own returns `KERN_FAILURE` regardless of what the user has
+clicked in System Settings.
+
+So the three features that read or write the game's memory work only when the app is
+launched with `sudo`:
+
+- practice mode's live stats,
+- reading a replay out of a running game,
+- injecting a replay into one.
+
+Everything else — the spawnset editor, asset editor, mod manager, replay editor's file
+handling, and custom leaderboards — needs no elevation and works normally.
+
+This is the one place the port changes shared UI, and it is worth understanding why. When
+memory is unavailable the honest answer differs by cause, and the two causes need different
+things from the user:
+
+| Status | Means | What the user is told |
+|---|---|---|
+| `Unresolved` | The game is not running | "Devil Daggers is not running." |
+| `Resolved` | The block was located | — |
+| `MemoryUnreadable` | The game's memory could not be read at all | Restart under `sudo`, and which features that affects |
+| `BlockNotFound` | Memory read fine, but holds no stats block | Start a run, or this is an unknown build |
+
+`MemoryUnreadable` and `BlockNotFound` are produced only by the macOS scan path. Windows and
+Linux resolve to `Unresolved` or `Resolved` and nothing else, so the branches that check for
+them are unreachable on those platforms by construction — the "game not running" screen is
+byte-for-byte what it was before this branch.
+
+Gating on `BlockAddressStatus` rather than on `IsInitialized` is deliberate. `IsInitialized`
+is also false when the game simply is not running, which happens on every platform, so
+branching on it would have changed Windows and Linux behaviour.
+
+## Where the game lives
+
+On macOS the game ships as an `.app` bundle, and `dd/`, `res/` and `mods/` live inside
+`Contents/Resources` rather than beside the executable. The bundle's parent directory is
+therefore *not* a valid installation directory and fails validation with
+`File 'dd/survival' does not exist.`
+
+`OSXValues.DefaultInstallationPath` points inside the bundle accordingly:
+
+```
+~/Library/Application Support/Steam/steamapps/common/devildaggers/Devil Daggers.app/Contents/Resources
+```
+
+The process is named `Devil Daggers` — capitals, and a space — where the Linux one is
+`devildaggers`, so process lookup normalises the name before comparing.
+
+## Finding the ddstats block
+
+Windows and Linux both derive from `MarkerOffsetMemoryService`: they read a pointer at an
+offset the DevilDaggers.info API supplies, and declare `RequiresMarkerOffset => true`.
+
+There is no API route serving that offset for macOS, so `OSXMemoryService` declares
+`RequiresMarkerOffset => false` and finds the block by scanning instead — walking every
+readable region of the game's address space via `mach_vm_region` and searching each for the
+block's marker.
+
+Four things about that scan are load-bearing:
+
+- **A marker match is not a block.** The game's own string literal contains the same bytes.
+  Every candidate is validated with `MainBlock.IsValid`, which checks the marker, its
+  terminating null, a plausible format version, and that both 32-byte name fields contain a
+  null. False positives are real and were observed during development.
+- **`MainBlock.IsValid` must be called before `new MainBlock(...)`.** The constructor slices
+  the name fields up to their null byte and throws `ArgumentOutOfRangeException` on a buffer
+  without one. On the render loop, that is a crash.
+- **The scan is expensive.** It reads on the order of gigabytes across a few hundred regions
+  and takes seconds, varying several-fold run to run with heap layout. The resolved address
+  is cached with the pid it was found in and reused until it stops reading back as a block, and
+  a scan that comes up empty sets a five-second cooldown before another may start — otherwise
+  the ~300 Hz render loop would start one continuously.
+- **Nothing in it may throw.** `GameMemoryServiceWrapper.Scan()` runs from that render loop,
+  so an escaping exception takes the app down instead of reporting the problem. Failures
+  return null or no-op and log their reason once behind a `bool` field, so the log does not
+  fill at 300 lines a second. This includes native symbol resolution: an unresolvable
+  P/Invoke throws at its *call* site, so those are wrapped in
+  `catch (DllNotFoundException or EntryPointNotFoundException)`.
+
+A read of an unmapped address returns `KERN_INVALID_ADDRESS` rather than signalling, so
+speculative probing during the walk is safe.
+
+Two conventions in the Mach bindings, both of which cost time to find:
+
+- **Omit `SetLastError`.** Mach reports failure through the `kern_return_t` return value, not
+  through `errno`.
+- **Pass `vm_region` info as an `int*`** from a `stackalloc int[9]`, rather than as an
+  `[Out] int[]`. This sidesteps `LibraryImport` array marshalling entirely.
+
+## OpenGL differences
+
+Two `#if OSX` branches in `Container.cs`, both about the context rather than about rendering:
+
+- macOS refuses to create a Core-profile context that is not also forward-compatible.
+  Without `OpenGLForwardCompat`, `glfwCreateWindow` returns null instead of a window, with
+  no error.
+- Debug output is `glDebugMessageCallback`, which is OpenGL 4.3 / `KHR_debug`. macOS caps at
+  4.1 and never exposed that extension, so the `Debug`-only debug context and its callback
+  are compiled out with `#if DEBUG && !OSX`. Windows and Linux debug builds keep both.
+
+## What is not supported
+
+- **Intel Macs.** `osx-x64` is not wired into the csproj and has not been tested.
+- **`AppOperatingSystem`.** The enum ships in the `DevilDaggersInfo.Web.ApiSpec.Tools`
+  package and has no macOS member, so the macOS build reports `Linux`. This only affects
+  what the server is told about the submitting client's OS. Adding a member upstream would
+  be the real fix.
+- **Release solution builds without a RID.** See [Building and running](#building-and-running).
+- **A published artifact.** Source builds only.
+
+## Where the platform code lives
+
+Platform compilation is driven by the `WINDOWS` / `LINUX` / `OSX` `DefineConstants` set in
+`DevilDaggersInfo.Tools.csproj`, and only four files switch on platform: `Container.cs`,
+`ContentManager.cs`, `Ui/Config/ConfigLayout.cs`, and the csproj itself. Everything else goes
+behind `INativeMemoryService`, `INativeWindowingService`, and `IPlatformSpecificValues`, with
+a parallel implementation under `NativeInterface/Services/{Windows,Linux,OSX}/` and a values
+class under `Platforms/`. A new `#if` anywhere else is a sign something belongs behind one of
+those three interfaces instead.

--- a/src/DevilDaggersInfo.Tools/Container.cs
+++ b/src/DevilDaggersInfo.Tools/Container.cs
@@ -178,9 +178,16 @@ internal sealed partial class Container : IContainer<Application>
 		glfw.WindowHint(WindowHintInt.ContextVersionMajor, 3);
 		glfw.WindowHint(WindowHintInt.ContextVersionMinor, 3);
 		glfw.WindowHint(WindowHintOpenGlProfile.OpenGlProfile, OpenGlProfile.Core);
+#if OSX
+		// macOS refuses to create a Core-profile context that is not also forward-compatible; without this hint,
+		// glfwCreateWindow silently returns null instead of a window.
+		glfw.WindowHint(WindowHintBool.OpenGLForwardCompat, true);
+#endif
 		glfw.WindowHint(WindowHintBool.Focused, true);
 		glfw.WindowHint(WindowHintBool.Resizable, true);
-#if DEBUG
+#if DEBUG && !OSX
+		// Not on macOS: debug output is glDebugMessageCallback, which is OpenGL 4.3 / KHR_debug. macOS caps at 4.1 and
+		// never exposed that extension, so requesting a debug context here only sets up a symbol lookup that fails.
 		glfw.WindowHint(WindowHintBool.OpenGLDebugContext, true);
 #endif
 		glfw.CheckError();
@@ -200,7 +207,7 @@ internal sealed partial class Container : IContainer<Application>
 
 		GL gl = GL.GetApi(glfw.GetProcAddress);
 
-#if DEBUG
+#if DEBUG && !OSX
 		// A debug context is requested in GetGlfw. Without a callback installed, the driver's diagnostics are discarded,
 		// which is how spec violations end up only being noticed as visual glitches on stricter drivers.
 		gl.Enable(EnableCap.DebugOutput);
@@ -219,7 +226,7 @@ internal sealed partial class Container : IContainer<Application>
 		return gl;
 	}
 
-#if DEBUG
+#if DEBUG && !OSX
 	private static void LogGlDebugMessage(ILogger logger, GLEnum source, GLEnum type, GLEnum severity, int length, nint message)
 	{
 		string text = System.Runtime.InteropServices.Marshal.PtrToStringAnsi(message, length);
@@ -270,12 +277,15 @@ internal sealed partial class Container : IContainer<Application>
 	}
 
 	[Factory(Scope.SingleInstance)]
-	private static unsafe WindowHandle* CreateWindow(Glfw glfw, GlfwInput glfwInput, UserCache userCache)
+	private static unsafe WindowHandle* CreateWindow(Glfw glfw, GlfwInput glfwInput, UserCache userCache, ILogger logger)
 	{
 		WindowHandle* window = glfw.CreateWindow(userCache.Model.WindowWidth, userCache.Model.WindowHeight, $"ddinfo tools {AssemblyUtils.EntryAssemblyVersionString}", null, null);
 		glfw.CheckError();
 		if (window == null)
+		{
+			logger.Error("Could not create window. Window pointer was null. On macOS this usually means the requested OpenGL Core-profile context was not also marked forward-compatible (WindowHintBool.OpenGLForwardCompat); see GetGlfw.");
 			throw new InvalidOperationException("Could not create window. Window pointer was null.");
+		}
 
 		glfw.SetCursorPosCallback(window, (_, x, y) => glfwInput.CursorPosCallback(x, y));
 		glfw.SetScrollCallback(window, (_, _, y) => glfwInput.MouseWheelCallback(y));
@@ -346,6 +356,8 @@ internal sealed partial class Container : IContainer<Application>
 		return new GameMemoryService(new NativeInterface.Services.Windows.WindowsMemoryService());
 #elif LINUX
 		return new GameMemoryService(new NativeInterface.Services.Linux.LinuxMemoryService(logger));
+#elif OSX
+		return new GameMemoryService(new NativeInterface.Services.OSX.OSXMemoryService(logger));
 #endif
 	}
 
@@ -356,6 +368,8 @@ internal sealed partial class Container : IContainer<Application>
 		return new GameWindowService(new NativeInterface.Services.Windows.WindowsWindowingService());
 #elif LINUX
 		return new GameWindowService(new NativeInterface.Services.Linux.LinuxWindowingService());
+#elif OSX
+		return new GameWindowService(new NativeInterface.Services.OSX.OSXWindowingService());
 #endif
 	}
 
@@ -368,6 +382,8 @@ internal sealed partial class Container : IContainer<Application>
 		return new WindowsValues();
 #elif LINUX
 		return new LinuxValues();
+#elif OSX
+		return new OSXValues();
 #endif
 	}
 }

--- a/src/DevilDaggersInfo.Tools/DevilDaggersInfo.Tools.csproj
+++ b/src/DevilDaggersInfo.Tools/DevilDaggersInfo.Tools.csproj
@@ -26,6 +26,12 @@
             <OutputType>Exe</OutputType>
           </PropertyGroup>
         </When>
+        <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">
+          <PropertyGroup>
+            <DefineConstants>$(DefineConstants);OSX</DefineConstants>
+            <OutputType>Exe</OutputType>
+          </PropertyGroup>
+        </When>
       </Choose>
     </When>
     <When Condition="'$(Configuration)' == 'Release'">
@@ -40,6 +46,12 @@
         <When Condition="'$(RuntimeIdentifier)' == 'linux-x64' Or '$(CI)' == 'true'">
           <PropertyGroup>
             <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
+            <OutputType>Exe</OutputType>
+          </PropertyGroup>
+        </When>
+        <When Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+          <PropertyGroup>
+            <DefineConstants>$(DefineConstants);OSX</DefineConstants>
             <OutputType>Exe</OutputType>
           </PropertyGroup>
         </When>

--- a/src/DevilDaggersInfo.Tools/GameMemory/GameMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/GameMemory/GameMemoryService.cs
@@ -8,10 +8,7 @@ internal sealed class GameMemoryService(INativeMemoryService nativeMemoryService
 {
 	public const int StatsBufferSize = 112;
 
-	private const int _mainBufferSize = 319;
-
-	private readonly byte[] _pointerBuffer = new byte[sizeof(long)];
-	private readonly byte[] _mainBuffer = new byte[_mainBufferSize];
+	private readonly byte[] _mainBuffer = new byte[MainBlock.Size];
 	private readonly byte[] _replayIdentifierBuffer = new byte[LocalReplayBinaryHeader.IdentifierLength];
 
 	private long _memoryBlockAddress;
@@ -22,20 +19,38 @@ internal sealed class GameMemoryService(INativeMemoryService nativeMemoryService
 
 	public bool IsInitialized { get; private set; }
 
-	public void Initialize(long ddstatsMarkerOffset)
+	/// <summary>
+	/// Whether <see cref="Initialize" /> needs the ddstats marker offset from the API on this platform.
+	/// </summary>
+	public bool RequiresMarkerOffset => nativeMemoryService.RequiresMarkerOffset;
+
+	/// <summary>
+	/// Why the address of the ddstats block is or is not known, so a game whose memory is off limits can be told apart
+	/// from a game that simply has no block to read.
+	/// </summary>
+	public BlockAddressStatus BlockAddressStatus { get; private set; }
+
+	/// <summary>
+	/// The address of the ddstats block; only meaningful while <see cref="BlockAddressStatus" /> is
+	/// <see cref="BlockAddressStatus.Resolved" />.
+	/// </summary>
+	public long BlockAddress => _memoryBlockAddress;
+
+	public void Initialize(long? ddstatsMarkerOffset)
 	{
 		_process = nativeMemoryService.GetDevilDaggersProcess();
-		if (_process?.MainModule == null)
+		if (_process == null)
 		{
+			BlockAddressStatus = BlockAddressStatus.Unresolved;
 			IsInitialized = false;
+			return;
 		}
-		else
-		{
-			_pointerBuffer.AsSpan().Clear();
-			nativeMemoryService.ReadMemory(_process, _process.MainModule.BaseAddress.ToInt64() + ddstatsMarkerOffset, _pointerBuffer, 0, sizeof(long));
-			_memoryBlockAddress = BitConverter.ToInt64(_pointerBuffer);
-			IsInitialized = true;
-		}
+
+		BlockAddressResult blockAddressResult = nativeMemoryService.ResolveBlockAddress(_process, ddstatsMarkerOffset);
+		BlockAddressStatus = blockAddressResult.Status;
+		IsInitialized = blockAddressResult.Status == BlockAddressStatus.Resolved;
+		if (IsInitialized)
+			_memoryBlockAddress = blockAddressResult.Address;
 	}
 
 	public void Scan()
@@ -43,7 +58,7 @@ internal sealed class GameMemoryService(INativeMemoryService nativeMemoryService
 		if (_process == null)
 			return;
 
-		nativeMemoryService.ReadMemory(_process, _memoryBlockAddress, _mainBuffer, 0, _mainBufferSize);
+		nativeMemoryService.ReadMemory(_process, _memoryBlockAddress, _mainBuffer, 0, MainBlock.Size);
 
 		MainBlockPrevious = MainBlock;
 		MainBlock = new MainBlock(_mainBuffer);

--- a/src/DevilDaggersInfo.Tools/GameMemory/MainBlock.cs
+++ b/src/DevilDaggersInfo.Tools/GameMemory/MainBlock.cs
@@ -1,11 +1,22 @@
 #pragma warning disable IDE1006 // Naming Styles
 
+using System.Buffers.Binary;
 using System.Text;
 
 namespace DevilDaggersInfo.Tools.GameMemory;
 
 internal readonly record struct MainBlock
 {
+	/// <summary>
+	/// The size of the whole block, in bytes.
+	/// </summary>
+	public const int Size = 319;
+
+	private const int _formatVersionOffset = 12;
+	private const int _playerNameOffset = 20;
+	private const int _replayPlayerNameOffset = 176;
+	private const int _nameFieldSize = 32;
+
 	public readonly string Marker = string.Empty;
 	public readonly int FormatVersion;
 
@@ -208,6 +219,38 @@ internal readonly record struct MainBlock
 		PlayReplayFromMemory = br.ReadBoolean();
 		GameMode = br.ReadByte();
 		TimeAttackOrRaceFinished = br.ReadBoolean();
+	}
+
+	/// <summary>
+	/// The bytes the game writes at the start of the block. Platforms with no marker offset to fetch find the block by
+	/// searching the game's memory for these.
+	/// </summary>
+	public static ReadOnlySpan<byte> MarkerBytes => "__ddstats__"u8;
+
+	/// <summary>
+	/// Whether <paramref name="buffer" /> holds a ddstats block, rather than one of the other copies of the marker
+	/// bytes lying around in the process - the game's own string literal, for one.
+	/// </summary>
+	/// <remarks>
+	/// This is only needed by platforms that find the block by searching for it; reading a pointer at the marker offset
+	/// cannot land on the wrong candidate. It also guarantees the constructor can parse the buffer: the name fields are
+	/// read up to their null terminator, and a buffer without one would throw.
+	/// </remarks>
+	public static bool IsValid(ReadOnlySpan<byte> buffer)
+	{
+		if (buffer.Length < Size)
+			return false;
+
+		if (!buffer[..MarkerBytes.Length].SequenceEqual(MarkerBytes) || buffer[MarkerBytes.Length] != 0)
+			return false;
+
+		// Every build whose layout is known writes 1 here. Allow a bump so a future one is not rejected out of hand,
+		// but not the arbitrary bytes that follow a stray copy of the marker.
+		int formatVersion = BinaryPrimitives.ReadInt32LittleEndian(buffer[_formatVersionOffset..]);
+		if (formatVersion is < 1 or > 1000)
+			return false;
+
+		return buffer.Slice(_playerNameOffset, _nameFieldSize).Contains((byte)0) && buffer.Slice(_replayPlayerNameOffset, _nameFieldSize).Contains((byte)0);
 	}
 
 	private static string Utf8StringFromBytes(byte[] bytes)

--- a/src/DevilDaggersInfo.Tools/GameMemoryServiceWrapper.cs
+++ b/src/DevilDaggersInfo.Tools/GameMemoryServiceWrapper.cs
@@ -1,4 +1,5 @@
 using DevilDaggersInfo.Tools.GameMemory;
+using DevilDaggersInfo.Tools.NativeInterface.Services;
 using DevilDaggersInfo.Tools.Networking;
 using DevilDaggersInfo.Tools.Networking.TaskHandlers;
 using DevilDaggersInfo.Tools.Platforms;
@@ -19,12 +20,14 @@ internal sealed class GameMemoryServiceWrapper(
 	public long? Marker { get; private set; }
 
 	/// <summary>
-	/// Scans game memory. If the marker is not known, fires the call to retrieve it, then returns false because memory can't be scanned until the HTTP call has returned successfully.
+	/// Scans game memory. On platforms that need the marker offset from the API, and where it is not known yet, fires the call to retrieve it and then returns false, because memory can't be scanned until the HTTP call has returned successfully.
 	/// </summary>
-	/// <returns>Whether the marker is known.</returns>
+	/// <returns>Whether memory could be scanned. Always true on platforms that have no marker offset to wait for; use <see cref="GameMemory.GameMemoryService.BlockAddressStatus" /> to find out how the scan itself went.</returns>
 	public bool Scan()
 	{
-		if (!Marker.HasValue)
+		// Not every platform locates the block by reading a pointer at an offset the API supplies; the ones that search
+		// the game's memory for it have nothing to download and nothing to wait for, and leave Marker null forever.
+		if (gameMemoryService.RequiresMarkerOffset && !Marker.HasValue)
 		{
 			if (!_tryDownloadMarker)
 				return false;
@@ -34,10 +37,27 @@ internal sealed class GameMemoryServiceWrapper(
 		}
 
 		// Always initialize the process, so we detach properly when the game exits.
-		gameMemoryService.Initialize(Marker.Value);
+		gameMemoryService.Initialize(Marker);
 		gameMemoryService.Scan();
 
 		return true;
+	}
+
+	/// <summary>
+	/// Explains why the ddstats block is not available, so that a refusal to read the game's memory - which on macOS
+	/// almost always means the app was not launched under sudo - is never presented to the user the same way as the
+	/// game simply not running.
+	/// </summary>
+	public string DescribeUnavailability()
+	{
+		return gameMemoryService.BlockAddressStatus switch
+		{
+			BlockAddressStatus.MemoryUnreadable =>
+				"The game's memory could not be read. On macOS, reading another program's memory requires administrator rights: quit ddinfo-tools and start it again with sudo. This only affects practice mode's live stats - the spawnset editor, asset editor, replay editor, mod manager, and custom leaderboards do not need it.",
+			BlockAddressStatus.BlockNotFound =>
+				"The game's memory was read, but holds no stats block yet. Start a run, or check that the game is a version this app knows.",
+			_ => "Devil Daggers is not running.",
+		};
 	}
 
 	private void InitializeMarker()

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/BlockAddressResult.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/BlockAddressResult.cs
@@ -1,0 +1,16 @@
+namespace DevilDaggersInfo.Tools.NativeInterface.Services;
+
+/// <summary>
+/// Where the ddstats block is, or why it is not known.
+/// </summary>
+/// <param name="Status">The outcome of the resolution attempt.</param>
+/// <param name="Address">The address of the block; only meaningful when <paramref name="Status" /> is <see cref="BlockAddressStatus.Resolved" />.</param>
+internal readonly record struct BlockAddressResult(BlockAddressStatus Status, long Address)
+{
+	public static BlockAddressResult Unresolved { get; } = new(BlockAddressStatus.Unresolved, 0);
+
+	public static BlockAddressResult Resolved(long address)
+	{
+		return new BlockAddressResult(BlockAddressStatus.Resolved, address);
+	}
+}

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/BlockAddressStatus.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/BlockAddressStatus.cs
@@ -1,0 +1,29 @@
+namespace DevilDaggersInfo.Tools.NativeInterface.Services;
+
+/// <summary>
+/// The outcome of resolving the address of the ddstats block in the running game. The failure cases are deliberately
+/// separate: "the game's memory is off limits" and "the game's memory holds no block" need different answers from the
+/// user, and collapsing them into "no game connected" hides both.
+/// </summary>
+internal enum BlockAddressStatus
+{
+	/// <summary>
+	/// Nothing has been resolved. The game is not running, or its main module is not available yet.
+	/// </summary>
+	Unresolved,
+
+	/// <summary>
+	/// The block was located.
+	/// </summary>
+	Resolved,
+
+	/// <summary>
+	/// The game's memory could not be read at all. On macOS this is almost always a launch without sudo.
+	/// </summary>
+	MemoryUnreadable,
+
+	/// <summary>
+	/// The game's memory was read, but no ddstats block was found in it.
+	/// </summary>
+	BlockNotFound,
+}

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/INativeMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/INativeMemoryService.cs
@@ -4,9 +4,27 @@ namespace DevilDaggersInfo.Tools.NativeInterface.Services;
 
 internal interface INativeMemoryService
 {
+	/// <summary>
+	/// Whether this platform needs the ddstats marker offset from the DevilDaggers.info API in order to locate the
+	/// block. Platforms that search the game's memory for the block have no offset to fetch, and no API route to fetch
+	/// one from.
+	/// </summary>
+	bool RequiresMarkerOffset { get; }
+
 	void WriteMemory(Process process, long address, byte[] bytes, int offset, int size);
 
 	void ReadMemory(Process process, long address, byte[] bytes, int offset, int size);
 
 	Process? GetDevilDaggersProcess();
+
+	/// <summary>
+	/// Resolves the address of the ddstats block inside <paramref name="process" />. How that is done is the platform's
+	/// business: reading a pointer at a known offset, or searching the game's memory for the block itself.
+	/// </summary>
+	/// <param name="process">The running game.</param>
+	/// <param name="ddstatsMarkerOffset">
+	/// The marker offset from the API, or <see langword="null" /> when <see cref="RequiresMarkerOffset" /> is
+	/// <see langword="false" /> and there is therefore nothing to fetch.
+	/// </param>
+	BlockAddressResult ResolveBlockAddress(Process process, long? ddstatsMarkerOffset);
 }

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/Linux/LinuxMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/Linux/LinuxMemoryService.cs
@@ -4,12 +4,12 @@ using System.Runtime.InteropServices;
 
 namespace DevilDaggersInfo.Tools.NativeInterface.Services.Linux;
 
-internal sealed partial class LinuxMemoryService(ILogger logger) : INativeMemoryService
+internal sealed partial class LinuxMemoryService(ILogger logger) : MarkerOffsetMemoryService
 {
 	private bool _loggedReadFailure;
 	private bool _loggedWriteFailure;
 
-	public void WriteMemory(Process process, long address, byte[] bytes, int offset, int size)
+	public override void WriteMemory(Process process, long address, byte[] bytes, int offset, int size)
 	{
 		// Mirror ReadMemory in not turning an empty request into a pointer into an empty array.
 		if (size <= 0)
@@ -47,7 +47,7 @@ internal sealed partial class LinuxMemoryService(ILogger logger) : INativeMemory
 		}
 	}
 
-	public void ReadMemory(Process process, long address, byte[] bytes, int offset, int size)
+	public override void ReadMemory(Process process, long address, byte[] bytes, int offset, int size)
 	{
 		// Callers can request an empty read (for example when the game reports a replay length of 0), which must not
 		// be turned into a pointer into an empty array.
@@ -90,7 +90,7 @@ internal sealed partial class LinuxMemoryService(ILogger logger) : INativeMemory
 		}
 	}
 
-	public Process? GetDevilDaggersProcess()
+	public override Process? GetDevilDaggersProcess()
 	{
 		return Array.Find(Process.GetProcesses(), p => p.ProcessName.StartsWith("devildaggers"));
 	}

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/MarkerOffsetMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/MarkerOffsetMemoryService.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+
+namespace DevilDaggersInfo.Tools.NativeInterface.Services;
+
+/// <summary>
+/// Base class for the platforms that locate the ddstats block by reading a pointer the game stores at a fixed offset
+/// from its main module, which the DevilDaggers.info API supplies. Only reading, writing, and finding the process are
+/// platform-specific; turning the marker offset into a block address is the same wherever the offset exists.
+/// </summary>
+internal abstract class MarkerOffsetMemoryService : INativeMemoryService
+{
+	private readonly byte[] _pointerBuffer = new byte[sizeof(long)];
+
+	/// <inheritdoc />
+	public bool RequiresMarkerOffset => true;
+
+	/// <inheritdoc />
+	public BlockAddressResult ResolveBlockAddress(Process process, long? ddstatsMarkerOffset)
+	{
+		if (process.MainModule == null || ddstatsMarkerOffset is not { } markerOffset)
+			return BlockAddressResult.Unresolved;
+
+		_pointerBuffer.AsSpan().Clear();
+		ReadMemory(process, process.MainModule.BaseAddress.ToInt64() + markerOffset, _pointerBuffer, 0, sizeof(long));
+		return BlockAddressResult.Resolved(BitConverter.ToInt64(_pointerBuffer));
+	}
+
+	/// <inheritdoc />
+	public abstract void WriteMemory(Process process, long address, byte[] bytes, int offset, int size);
+
+	/// <inheritdoc />
+	public abstract void ReadMemory(Process process, long address, byte[] bytes, int offset, int size);
+
+	/// <inheritdoc />
+	public abstract Process? GetDevilDaggersProcess();
+}

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/OSX/OSXMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/OSX/OSXMemoryService.cs
@@ -1,0 +1,609 @@
+using DevilDaggersInfo.Tools.GameMemory;
+using Serilog;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace DevilDaggersInfo.Tools.NativeInterface.Services.OSX;
+
+internal sealed partial class OSXMemoryService(ILogger logger) : INativeMemoryService
+{
+	private const int _kernSuccess = 0;
+	private const int _kernInvalidArgument = 4;
+	private const int _kernFailure = 5;
+
+	private const int _vmProtRead = 0x01;
+	private const int _vmRegionBasicInfo64 = 9;
+	private const int _vmRegionBasicInfoCount64 = 9;
+
+	// Regions are read in chunks rather than whole, because a single region can be gigabytes wide.
+	private const int _scanChunkSize = 4 * 1024 * 1024;
+
+	// A full scan reads gigabytes and takes seconds, and it runs from the ~300 Hz render loop, so a scan that came up
+	// empty must not be retried on the next frame.
+	private const long _rescanCooldownMs = 5000;
+
+	private readonly byte[] _blockBuffer = new byte[MainBlock.Size];
+
+	private bool _loggedWriteFailure;
+	private bool _loggedReadFailure;
+	private bool _loggedProcessLookupFailure;
+	private bool _loggedTaskFailure;
+	private bool _loggedScanUnreadable;
+	private bool _loggedScanNotFound;
+
+	// The scan buffer is kept between scans rather than reallocated; it is large enough to land on the large object
+	// heap. Null until the first scan, so a session that never scans never pays for it.
+	private byte[]? _scanBuffer;
+
+	// The address the ddstats block was last found at, alongside the pid it was found in. 0 means nothing is cached.
+	private long _blockAddress;
+	private int _blockAddressProcessId;
+
+	// Environment.TickCount64 before which no new scan may start, and the status the last scan ended on, which is what
+	// callers get while the cooldown holds.
+	private long _nextScanTimestamp;
+	private BlockAddressStatus _lastScanStatus;
+
+	// task_for_pid is privileged and comparatively expensive, so the port is acquired once and kept for as long as it
+	// belongs to the process we are asked about. _taskPort is 0 when nothing is cached.
+	private uint _taskPort;
+	private int _taskPortProcessId;
+
+	// Our own task port, resolved once. 0 means nothing resolved yet.
+	private uint _selfTaskPort;
+	private bool _loggedSelfTaskFailure;
+
+	/// <summary>
+	/// macOS has no marker offset to fetch. The DevilDaggers.info API serves one for Windows and one for Linux, and
+	/// <c>AppOperatingSystem</c> has no third member to ask with, so the block is found by searching for it instead.
+	/// </summary>
+	public bool RequiresMarkerOffset => false;
+
+	/// <inheritdoc />
+	public BlockAddressResult ResolveBlockAddress(Process process, long? ddstatsMarkerOffset)
+	{
+		// The block does not move while the game runs, so an address found once is reused until it stops reading back
+		// as a block - which is what a restart, a different build, or the game freeing it all look like from here.
+		if (_blockAddress != 0 && _blockAddressProcessId == process.Id && IsBlockAt(process, _blockAddress))
+			return BlockAddressResult.Resolved(_blockAddress);
+
+		if (_blockAddress != 0)
+		{
+			_blockAddress = 0;
+			_blockAddressProcessId = 0;
+
+			// The cached address has stopped reading back as a block. Until a scan says otherwise the honest answer is
+			// that there is no block, rather than the outcome of the scan that found the one which has since gone.
+			_lastScanStatus = BlockAddressStatus.BlockNotFound;
+		}
+
+		if (Environment.TickCount64 < _nextScanTimestamp)
+			return new BlockAddressResult(_lastScanStatus, 0);
+
+		_lastScanStatus = ScanForBlock(process, out long scannedAddress);
+		_nextScanTimestamp = Environment.TickCount64 + _rescanCooldownMs;
+
+		if (_lastScanStatus != BlockAddressStatus.Resolved)
+			return new BlockAddressResult(_lastScanStatus, 0);
+
+		_blockAddress = scannedAddress;
+		_blockAddressProcessId = process.Id;
+		return BlockAddressResult.Resolved(scannedAddress);
+	}
+
+	public void WriteMemory(Process process, long address, byte[] bytes, int offset, int size)
+	{
+		// Mirror ReadMemory in not turning an empty request into a pointer into an empty array.
+		if (size <= 0)
+			return;
+
+		// A failure here has already been logged by TryGetTaskPort itself.
+		if (!TryGetTaskPort(process, out uint task))
+			return;
+
+		int kernReturn;
+		unsafe
+		{
+			fixed (byte* localBase = &bytes[offset])
+			{
+				kernReturn = MachVmWrite(task, (ulong)address, (ulong)localBase, (uint)size);
+			}
+		}
+
+		if (kernReturn == _kernSuccess)
+		{
+			_loggedWriteFailure = false;
+			return;
+		}
+
+		if (kernReturn == _kernInvalidArgument)
+		{
+			// The task port itself is no longer valid - the game most likely exited. Drop it so the next write
+			// re-acquires one instead of failing forever against a dead port.
+			_taskPort = 0;
+			_taskPortProcessId = 0;
+		}
+
+		if (_loggedWriteFailure)
+			return;
+
+		_loggedWriteFailure = true;
+		logger.Error("Could not write game memory: mach_vm_write returned kern_return_t {KernReturn} ({Description}) writing {Size} bytes at 0x{Address:X8}. Quit ddinfo-tools and start it again under sudo - writing another process's memory requires root on macOS.", kernReturn, DescribeKernReturn(kernReturn), size, address);
+	}
+
+	public void ReadMemory(Process process, long address, byte[] bytes, int offset, int size)
+	{
+		// Callers can request an empty read (for example when the game reports a replay length of 0), which must not
+		// be turned into a pointer into an empty array.
+		if (size <= 0)
+			return;
+
+		// Callers keep scanning after the block address failed to resolve, and the game leaves the stats and replay
+		// pointers null outside a run, so a read of address 0 is routine and is not a fault worth reporting. Why the
+		// address is unknown has already been logged by ResolveBlockAddress.
+		if (address == 0)
+		{
+			Array.Clear(bytes, offset, size);
+			return;
+		}
+
+		if (!TryGetTaskPort(process, out uint task))
+		{
+			// A read that never happened leaves the buffer holding whatever was in it before, which the callers would
+			// happily parse as game state. Clear it so they observe zeroes instead of stale data.
+			Array.Clear(bytes, offset, size);
+			return;
+		}
+
+		int kernReturn = ReadInto(task, (ulong)address, bytes.AsSpan(offset, size), out ulong bytesRead);
+		if (kernReturn == _kernSuccess && bytesRead == (ulong)size)
+		{
+			_loggedReadFailure = false;
+			return;
+		}
+
+		// A failed or partial read leaves the buffer holding whatever was in it before, which the callers would happily
+		// parse as game state. Clear it so they observe zeroes instead of stale data. Refused reads are the common case
+		// on macOS, so this matters more here than it does on Linux.
+		Array.Clear(bytes, offset, size);
+
+		if (kernReturn == _kernInvalidArgument)
+		{
+			// The task port itself is no longer valid - the game most likely exited. Drop it so the next read
+			// re-acquires one instead of failing forever against a dead port.
+			_taskPort = 0;
+			_taskPortProcessId = 0;
+		}
+
+		if (_loggedReadFailure)
+			return;
+
+		_loggedReadFailure = true;
+		if (kernReturn != _kernSuccess)
+			logger.Error("Could not read game memory: mach_vm_read_overwrite returned kern_return_t {KernReturn} ({Description}) reading {Size} bytes at 0x{Address:X8}. {Region}", kernReturn, DescribeKernReturn(kernReturn), size, address, DescribeRegion(task, (ulong)address));
+		else
+			logger.Error("Could not read game memory: mach_vm_read_overwrite read {BytesRead} of {Size} requested bytes at 0x{Address:X8}.", bytesRead, size, address);
+	}
+
+	public Process? GetDevilDaggersProcess()
+	{
+		// The macOS process is named "Devil Daggers" - capitals and a space - where the Linux one is "devildaggers",
+		// so the name has to be normalised before it can be compared.
+		Process? process = Array.Find(Process.GetProcesses(), p => Normalize(p.ProcessName).StartsWith("devildaggers", StringComparison.Ordinal));
+		if (process != null)
+		{
+			_loggedProcessLookupFailure = false;
+			return process;
+		}
+
+		if (!_loggedProcessLookupFailure)
+		{
+			_loggedProcessLookupFailure = true;
+			logger.Error("Could not locate the Devil Daggers process. Start Devil Daggers from Steam, then try again. If it is running, its process name is not 'Devil Daggers' and this build cannot find it.");
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Lowercases and strips spaces so the macOS process name "Devil Daggers" compares equal to "devildaggers".
+	/// </summary>
+	private static string Normalize(string processName)
+	{
+		return processName.Replace(" ", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+	}
+
+	/// <summary>
+	/// Walks every readable region of the game's address space looking for the ddstats block.
+	/// </summary>
+	/// <returns>
+	/// <see cref="BlockAddressStatus.Resolved" />, having set <paramref name="blockAddress" />, or the reason the block
+	/// could not be found. A scan that could not read a single byte is a permissions problem and is reported separately
+	/// from a scan that read the whole address space and found no block in it.
+	/// </returns>
+	private BlockAddressStatus ScanForBlock(Process process, out long blockAddress)
+	{
+		blockAddress = 0;
+
+		// TryGetTaskPort logs the sudo advice for us when this fails.
+		if (!TryGetTaskPort(process, out uint task))
+			return BlockAddressStatus.MemoryUnreadable;
+
+		byte[] buffer = _scanBuffer ??= new byte[_scanChunkSize];
+		int markerLength = MainBlock.MarkerBytes.Length;
+
+		ulong regionAddress = 0;
+		ulong bytesRead = 0;
+		int regionsSeen = 0;
+		int regionsRead = 0;
+
+		while (true)
+		{
+			// Walked off the top of the address space.
+			if (!TryGetRegion(task, ref regionAddress, out ulong regionSize, out int protection))
+				break;
+
+			regionsSeen++;
+
+			// A zero-width region would leave the walk asking about the same address forever.
+			if (regionSize == 0)
+				break;
+
+			if ((protection & _vmProtRead) == 0)
+			{
+				regionAddress += regionSize;
+				continue;
+			}
+
+			bool regionRead = false;
+			ulong offset = 0;
+			while (offset < regionSize)
+			{
+				int chunkSize = (int)Math.Min((ulong)_scanChunkSize, regionSize - offset);
+				bool isLastChunk = (ulong)chunkSize == regionSize - offset;
+
+				int kernReturn = ReadInto(task, regionAddress + offset, buffer.AsSpan(0, chunkSize), out ulong chunkBytesRead);
+				if (kernReturn == _kernSuccess && chunkBytesRead > 0)
+				{
+					regionRead = true;
+					bytesRead += chunkBytesRead;
+
+					long found = FindBlock(process, buffer.AsSpan(0, (int)chunkBytesRead), (long)(regionAddress + offset));
+					if (found != 0)
+					{
+						_loggedScanUnreadable = false;
+						_loggedScanNotFound = false;
+						logger.Information("Found the ddstats block at 0x{BlockAddress:X8} in Devil Daggers (process {ProcessId}), after reading {MegabytesRead} MB across {RegionsSeen} memory regions.", found, process.Id, bytesRead / (1024 * 1024), regionsSeen);
+
+						blockAddress = found;
+						return BlockAddressStatus.Resolved;
+					}
+				}
+
+				if (isLastChunk)
+					break;
+
+				// Overlap the next chunk by the marker length so a marker straddling the boundary is still found. This
+				// branch only runs on a full-size chunk, so it always moves forward.
+				offset += (ulong)chunkSize - (ulong)(markerLength - 1);
+			}
+
+			if (regionRead)
+				regionsRead++;
+
+			regionAddress += regionSize;
+		}
+
+		if (bytesRead == 0)
+		{
+			_loggedScanNotFound = false;
+			if (!_loggedScanUnreadable)
+			{
+				_loggedScanUnreadable = true;
+				logger.Error("Could not read the memory of Devil Daggers (process {ProcessId}): a task port was acquired, but all {RegionsSeen} of its memory regions refused to be read. Quit ddinfo-tools and start it again under sudo.", process.Id, regionsSeen);
+			}
+
+			return BlockAddressStatus.MemoryUnreadable;
+		}
+
+		_loggedScanUnreadable = false;
+		if (!_loggedScanNotFound)
+		{
+			_loggedScanNotFound = true;
+			logger.Error("Read {MegabytesRead} MB across {RegionsRead} of {RegionsSeen} memory regions of Devil Daggers (process {ProcessId}), but found no ddstats block in it. Reading the game's memory works, so this is not a permissions problem: the game either has not created the block yet, or is a build whose layout this app does not know. Retrying every {RescanCooldownSeconds} seconds.", bytesRead / (1024 * 1024), regionsRead, regionsSeen, process.Id, _rescanCooldownMs / 1000);
+		}
+
+		return BlockAddressStatus.BlockNotFound;
+	}
+
+	/// <summary>
+	/// Searches one chunk of the game's memory for the ddstats block, rejecting the copies of the marker that are not
+	/// one - the game's own string literal, for instance.
+	/// </summary>
+	/// <returns>The address of the block, or 0 when this chunk holds none.</returns>
+	private long FindBlock(Process process, ReadOnlySpan<byte> chunk, long chunkAddress)
+	{
+		ReadOnlySpan<byte> marker = MainBlock.MarkerBytes;
+
+		int searchFrom = 0;
+		while (searchFrom <= chunk.Length - marker.Length)
+		{
+			int index = chunk[searchFrom..].IndexOf(marker);
+			if (index < 0)
+				return 0;
+
+			index += searchFrom;
+
+			long candidate = chunkAddress + index;
+			if (IsBlockAt(process, candidate))
+				return candidate;
+
+			searchFrom = index + 1;
+		}
+
+		return 0;
+	}
+
+	/// <summary>
+	/// Reads the block at <paramref name="address" /> and checks that it is one, both to reject false hits during a
+	/// scan and to confirm a cached address still holds the block.
+	/// </summary>
+	/// <remarks>
+	/// This deliberately does not go through <see cref="ReadMemory" />: a candidate that turns out not to be a block,
+	/// or a block that has gone away because the game exited, is an expected answer rather than a failure worth
+	/// logging.
+	/// </remarks>
+	private bool IsBlockAt(Process process, long address)
+	{
+		if (!TryGetTaskPort(process, out uint task))
+			return false;
+
+		int kernReturn = ReadInto(task, (ulong)address, _blockBuffer, out ulong bytesRead);
+		return kernReturn == _kernSuccess && bytesRead == MainBlock.Size && MainBlock.IsValid(_blockBuffer);
+	}
+
+	/// <summary>
+	/// Reads our own Mach task port, which <c>task_for_pid</c> needs as its first argument.
+	/// </summary>
+	/// <remarks>
+	/// libsystem_kernel exports <c>mach_task_self</c> as a real function, which <see cref="MachTaskSelf"/> binds, but
+	/// that export is a compatibility shim rather than the documented contract: in <c>&lt;mach/mach_init.h&gt;</c> the
+	/// call is a macro over an extern variable.
+	/// <code>
+	/// extern mach_port_t mach_task_self_;
+	/// #define mach_task_self() mach_task_self_
+	/// </code>
+	/// So the function is tried first and the variable is read as a fallback if a future macOS ever drops the export.
+	/// Both routes are wrapped, because an unresolvable P/Invoke throws at its call site - which for a memory service
+	/// is inside GameMemoryServiceWrapper.Scan() on the ~300 Hz render loop, where an escaping exception would take the
+	/// whole app down instead of reporting the problem.
+	/// </remarks>
+	private bool TryGetSelfTaskPort(out uint selfTask)
+	{
+		if (_selfTaskPort != 0)
+		{
+			selfTask = _selfTaskPort;
+			return true;
+		}
+
+		selfTask = 0;
+
+		string functionFailure = TryReadSelfTaskPortFromFunction(out selfTask);
+		if (functionFailure.Length > 0)
+		{
+			string variableFailure = TryReadSelfTaskPortFromVariable(out selfTask);
+			if (variableFailure.Length > 0)
+			{
+				selfTask = 0;
+
+				if (_loggedSelfTaskFailure)
+					return false;
+
+				_loggedSelfTaskFailure = true;
+				logger.Error("Could not read game memory: could not look up this process's own Mach task port. mach_task_self() failed because {FunctionFailure}, and reading the mach_task_self_ variable failed because {VariableFailure}. This build cannot read Devil Daggers' memory on this version of macOS.", functionFailure, variableFailure);
+				return false;
+			}
+		}
+
+		_selfTaskPort = selfTask;
+		_loggedSelfTaskFailure = false;
+		return true;
+	}
+
+	/// <summary>
+	/// Calls the exported <c>mach_task_self</c> function. Returns an empty string on success, or a description of why
+	/// it could not be used.
+	/// </summary>
+	private static string TryReadSelfTaskPortFromFunction(out uint selfTask)
+	{
+		selfTask = 0;
+
+		try
+		{
+			selfTask = MachTaskSelf();
+		}
+		catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException)
+		{
+			return string.Create(CultureInfo.InvariantCulture, $"the symbol could not be resolved ({ex.GetType().Name}: {ex.Message})");
+		}
+
+		if (selfTask != 0)
+			return string.Empty;
+
+		return "it returned a null port";
+	}
+
+	/// <summary>
+	/// Reads the <c>mach_task_self_</c> extern variable that <c>mach_task_self()</c> is a macro over. Returns an empty
+	/// string on success, or a description of why it could not be used.
+	/// </summary>
+	private static string TryReadSelfTaskPortFromVariable(out uint selfTask)
+	{
+		selfTask = 0;
+
+		try
+		{
+			nint export = NativeLibrary.GetExport(NativeLibrary.Load("libc"), "mach_task_self_");
+
+			// mach_port_t is a 32-bit unsigned integer.
+			selfTask = (uint)Marshal.ReadInt32(export);
+		}
+		catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException or ArgumentNullException)
+		{
+			return string.Create(CultureInfo.InvariantCulture, $"resolving the symbol threw {ex.GetType().Name}: {ex.Message}");
+		}
+
+		if (selfTask != 0)
+			return string.Empty;
+
+		return "the symbol holds a null port";
+	}
+
+	private bool TryGetTaskPort(Process process, out uint task)
+	{
+		if (_taskPort != 0 && _taskPortProcessId == process.Id)
+		{
+			task = _taskPort;
+			return true;
+		}
+
+		// Anything cached belongs to a different process (the game was restarted); it is useless now.
+		_taskPort = 0;
+		_taskPortProcessId = 0;
+
+		if (!TryGetSelfTaskPort(out uint selfTask))
+		{
+			task = 0;
+			return false;
+		}
+
+		int kernReturn = TaskForPid(selfTask, process.Id, out uint acquiredTask);
+		if (kernReturn == _kernSuccess && acquiredTask != 0)
+		{
+			_taskPort = acquiredTask;
+			_taskPortProcessId = process.Id;
+			_loggedTaskFailure = false;
+			task = acquiredTask;
+			return true;
+		}
+
+		task = 0;
+
+		if (_loggedTaskFailure)
+			return false;
+
+		_loggedTaskFailure = true;
+		if (kernReturn == _kernFailure)
+			logger.Error("Could not access the memory of Devil Daggers (process {ProcessId}): task_for_pid returned KERN_FAILURE (5), which on macOS means the request was not permitted. Quit ddinfo-tools and start it again under sudo - reading another process's memory requires root on macOS.", process.Id);
+		else
+			logger.Error("Could not access the memory of Devil Daggers (process {ProcessId}): task_for_pid returned kern_return_t {KernReturn} ({Description}). If ddinfo-tools was not started under sudo, start it again under sudo - reading another process's memory requires root on macOS.", process.Id, kernReturn, DescribeKernReturn(kernReturn));
+
+		return false;
+	}
+
+	/// <summary>
+	/// Reads as much of the task's memory as <paramref name="destination" /> holds into it. This is the only place
+	/// that pins a buffer and calls <c>mach_vm_read_overwrite</c>; what a refusal or a short read means is the
+	/// caller's business, because it differs - a scan probing a region expects both, a block read does not.
+	/// </summary>
+	/// <returns>The <c>kern_return_t</c> the read returned.</returns>
+	private static int ReadInto(uint task, ulong address, Span<byte> destination, out ulong bytesRead)
+	{
+		ulong read = 0;
+		int kernReturn;
+		unsafe
+		{
+			fixed (byte* localBase = destination)
+			{
+				kernReturn = MachVmReadOverwrite(task, address, (ulong)destination.Length, (ulong)localBase, ref read);
+			}
+		}
+
+		bytesRead = read;
+		return kernReturn;
+	}
+
+	/// <summary>
+	/// Describes the mapping the address falls in, so a refused read can be told apart from a read of memory the game
+	/// never mapped in the first place.
+	/// </summary>
+	private static string DescribeRegion(uint task, ulong address)
+	{
+		ulong regionAddress = address;
+		if (!TryGetRegion(task, ref regionAddress, out _, out int protection))
+			return "The address lies above every mapped region in the process.";
+
+		// mach_vm_region reports the first region at or above the requested address, so a higher start address means
+		// the requested address is not mapped at all.
+		if (regionAddress > address)
+			return string.Create(CultureInfo.InvariantCulture, $"The address is not mapped; the nearest mapping starts at 0x{regionAddress:X8}.");
+
+		return (protection & _vmProtRead) == 0
+			? string.Create(CultureInfo.InvariantCulture, $"The address lies in an unreadable region at 0x{regionAddress:X8} (protection 0x{protection:X}).")
+			: string.Create(CultureInfo.InvariantCulture, $"The address lies in a readable region at 0x{regionAddress:X8} (protection 0x{protection:X}), so the read itself was refused.");
+	}
+
+	/// <summary>
+	/// Looks up the first region the task has mapped at or above <paramref name="address" />, which
+	/// <c>mach_vm_region</c> reports by moving <paramref name="address" /> to the start of the region it found. This
+	/// is the only place that stack-allocates the info block and knows which of its fields holds the protection.
+	/// </summary>
+	/// <returns>
+	/// Whether a region was found. False means the address is above everything the process has mapped, which is how
+	/// a walk of the whole address space reaches its end.
+	/// </returns>
+	private static bool TryGetRegion(uint task, ref ulong address, out ulong size, out int protection)
+	{
+		ulong regionSize = 0;
+		int infoCount = _vmRegionBasicInfoCount64;
+
+		int kernReturn;
+		unsafe
+		{
+			int* info = stackalloc int[_vmRegionBasicInfoCount64];
+			kernReturn = MachVmRegion(task, ref address, ref regionSize, _vmRegionBasicInfo64, info, ref infoCount, out _);
+
+			// The first field of vm_region_basic_info_64 is the current protection.
+			protection = kernReturn == _kernSuccess ? info[0] : 0;
+		}
+
+		size = regionSize;
+		return kernReturn == _kernSuccess;
+	}
+
+	private static string DescribeKernReturn(int kernReturn)
+	{
+		return kernReturn switch
+		{
+			1 => "KERN_INVALID_ADDRESS",
+			2 => "KERN_PROTECTION_FAILURE",
+			_kernInvalidArgument => "KERN_INVALID_ARGUMENT, usually a dead or unknown process",
+			_kernFailure => "KERN_FAILURE, almost always 'not permitted'",
+			_ => "see mach/kern_return.h",
+		};
+	}
+
+	// macOS has no process_vm_readv equivalent; reading another process goes through Mach. These signatures were
+	// verified against the running game. Mach calls report failure through their kern_return_t result rather than
+	// errno, so there is nothing to gain from SetLastError here.
+	[LibraryImport("libc", EntryPoint = "mach_task_self")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static partial uint MachTaskSelf();
+
+	[LibraryImport("libc", EntryPoint = "task_for_pid")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static partial int TaskForPid(uint targetTport, int pid, out uint task);
+
+	[LibraryImport("libc", EntryPoint = "mach_vm_read_overwrite")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static partial int MachVmReadOverwrite(uint task, ulong address, ulong size, ulong data, ref ulong outSize);
+
+	[LibraryImport("libc", EntryPoint = "mach_vm_write")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static partial int MachVmWrite(uint task, ulong address, ulong data, uint dataCount);
+
+	[LibraryImport("libc", EntryPoint = "mach_vm_region")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+	private static unsafe partial int MachVmRegion(uint task, ref ulong address, ref ulong size, int flavor, int* info, ref int infoCount, out uint objectName);
+}

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/OSX/OSXWindowingService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/OSX/OSXWindowingService.cs
@@ -1,0 +1,12 @@
+using System.Numerics;
+
+namespace DevilDaggersInfo.Tools.NativeInterface.Services.OSX;
+
+internal sealed class OSXWindowingService : INativeWindowingService
+{
+	public Vector2 GetWindowPosition()
+	{
+		// TODO: Implement.
+		return default;
+	}
+}

--- a/src/DevilDaggersInfo.Tools/NativeInterface/Services/Windows/WindowsMemoryService.cs
+++ b/src/DevilDaggersInfo.Tools/NativeInterface/Services/Windows/WindowsMemoryService.cs
@@ -3,20 +3,20 @@ using System.Runtime.InteropServices;
 
 namespace DevilDaggersInfo.Tools.NativeInterface.Services.Windows;
 
-internal sealed class WindowsMemoryService : INativeMemoryService
+internal sealed class WindowsMemoryService : MarkerOffsetMemoryService
 {
-	public Process? GetDevilDaggersProcess()
+	public override Process? GetDevilDaggersProcess()
 	{
 		Process[] ddProcesses = Process.GetProcessesByName("dd");
 		return Array.Find(ddProcesses, p => p.MainWindowTitle == "Devil Daggers");
 	}
 
-	public void ReadMemory(Process process, long address, byte[] bytes, int offset, int size)
+	public override void ReadMemory(Process process, long address, byte[] bytes, int offset, int size)
 	{
 		ReadProcessMemory(process.Handle, new IntPtr(address), bytes, (uint)size, out _);
 	}
 
-	public void WriteMemory(Process process, long address, byte[] bytes, int offset, int size)
+	public override void WriteMemory(Process process, long address, byte[] bytes, int offset, int size)
 	{
 		WriteProcessMemory(process.Handle, new IntPtr(address), bytes, (uint)size, out _);
 	}

--- a/src/DevilDaggersInfo.Tools/Platforms/OSXValues.cs
+++ b/src/DevilDaggersInfo.Tools/Platforms/OSXValues.cs
@@ -1,0 +1,16 @@
+using DevilDaggersInfo.Web.ApiSpec.Tools;
+
+namespace DevilDaggersInfo.Tools.Platforms;
+
+internal sealed class OSXValues : IPlatformSpecificValues
+{
+	// AppOperatingSystem ships in DevilDaggersInfo.Web.ApiSpec.Tools (an external NuGet package) and has no macOS
+	// member. Reporting Linux is the least-bad option available from this repo; it only affects what the server is
+	// told about the submitting client's OS.
+	public AppOperatingSystem AppOperatingSystem => AppOperatingSystem.Linux;
+
+	// The Mac build ships as an .app bundle. Unlike Windows and Linux, where dd/, res/ and mods/ sit beside the
+	// executable, on macOS they live inside Contents/Resources — so the bundle's parent directory is NOT a valid
+	// installation directory and fails validation with "File 'dd/survival' does not exist."
+	public string DefaultInstallationPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Steam", "steamapps", "common", "devildaggers", "Devil Daggers.app", "Contents", "Resources");
+}

--- a/src/DevilDaggersInfo.Tools/Ui/Config/ConfigLayout.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/Config/ConfigLayout.cs
@@ -15,6 +15,11 @@ internal sealed class ConfigLayout(GameInstallationValidator gameInstallationVal
 		const string examplePath = "/home/{USERNAME}/.local/share/Steam/steamapps/common/devildaggers/";
 #elif WINDOWS
 		const string examplePath = """C:\Program Files (x86)\Steam\steamapps\common\devildaggers""";
+#elif OSX
+		// The Mac build ships as an .app bundle, so dd/, res/ and mods/ live inside Contents/Resources rather than
+		// beside the executable as they do on Windows and Linux. Pointing at the bundle's parent fails validation
+		// with "File 'dd/survival' does not exist."
+		const string examplePath = "/Users/{USERNAME}/Library/Application Support/Steam/steamapps/common/devildaggers/Devil Daggers.app/Contents/Resources";
 #endif
 #pragma warning restore S1075
 

--- a/src/DevilDaggersInfo.Tools/Ui/CustomLeaderboards/StateChild.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/CustomLeaderboards/StateChild.cs
@@ -1,10 +1,12 @@
+using DevilDaggersInfo.Tools.GameMemory;
+using DevilDaggersInfo.Tools.NativeInterface.Services;
 using DevilDaggersInfo.Tools.Utils;
 using Hexa.NET.ImGui;
 using System.Numerics;
 
 namespace DevilDaggersInfo.Tools.Ui.CustomLeaderboards;
 
-internal sealed class StateChild(RecordingLogic recordingLogic, GameMemoryServiceWrapper gameMemoryServiceWrapper, SurvivalFileWatcher survivalFileWatcher)
+internal sealed class StateChild(RecordingLogic recordingLogic, GameMemoryServiceWrapper gameMemoryServiceWrapper, GameMemoryService gameMemoryService, SurvivalFileWatcher survivalFileWatcher)
 {
 	public void Render()
 	{
@@ -16,7 +18,10 @@ internal sealed class StateChild(RecordingLogic recordingLogic, GameMemoryServic
 		ImGui.TableNextColumn();
 		ImGui.Text("Memory");
 		ImGui.TableNextColumn();
-		ImGui.Text(gameMemoryServiceWrapper.Marker.HasValue ? Inline.Utf8($"0x{gameMemoryServiceWrapper.Marker.Value:X}") : "Waiting..."u8);
+		ImGui.Text(GetMemoryText());
+		if (ImGui.IsItemHovered())
+			ImGui.SetTooltip(GetMemoryTooltip());
+
 		ImGui.TableNextRow();
 
 		ImGui.TableNextColumn();
@@ -38,5 +43,37 @@ internal sealed class StateChild(RecordingLogic recordingLogic, GameMemoryServic
 		ImGui.TableNextRow();
 
 		ImGui.EndTable();
+	}
+
+	/// <summary>
+	/// Where the game's stats block is, or why it is not known. Platforms that fetch a marker offset from the API show
+	/// that offset; platforms that search the game's memory for the block show how that search went.
+	/// </summary>
+	private ReadOnlySpan<byte> GetMemoryText()
+	{
+		if (gameMemoryService.RequiresMarkerOffset)
+			return gameMemoryServiceWrapper.Marker.HasValue ? Inline.Utf8($"0x{gameMemoryServiceWrapper.Marker.Value:X}") : "Waiting..."u8;
+
+		return gameMemoryService.BlockAddressStatus switch
+		{
+			BlockAddressStatus.Resolved => Inline.Utf8($"0x{gameMemoryService.BlockAddress:X}"),
+			BlockAddressStatus.MemoryUnreadable => "No access"u8,
+			BlockAddressStatus.BlockNotFound => "Not found"u8,
+			_ => "Waiting..."u8,
+		};
+	}
+
+	private ReadOnlySpan<byte> GetMemoryTooltip()
+	{
+		if (gameMemoryService.RequiresMarkerOffset)
+			return "The offset the DevilDaggers.info API gives for the game's stats block."u8;
+
+		return gameMemoryService.BlockAddressStatus switch
+		{
+			BlockAddressStatus.Resolved => "The address the game's stats block was found at."u8,
+			BlockAddressStatus.MemoryUnreadable => "The game's memory could not be read. Quit ddinfo-tools and start it again under sudo."u8,
+			BlockAddressStatus.BlockNotFound => "The game's memory was read, but holds no stats block. Start a run, or check that the game is a version this app knows."u8,
+			_ => "Waiting for the game to start."u8,
+		};
 	}
 }

--- a/src/DevilDaggersInfo.Tools/Ui/Practice/RunAnalysis/RunAnalysisWindow.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/Practice/RunAnalysis/RunAnalysisWindow.cs
@@ -1,4 +1,5 @@
 using DevilDaggersInfo.Tools.GameMemory;
+using DevilDaggersInfo.Tools.NativeInterface.Services;
 using DevilDaggersInfo.Tools.Ui.Practice.RunAnalysis.Data;
 using Hexa.NET.ImGui;
 
@@ -32,8 +33,18 @@ internal sealed class RunAnalysisWindow(GameMemoryServiceWrapper gameMemoryServi
 		ImGuiUtils.SetNextWindowMinSize(512, 1024);
 		if (ImGui.Begin("Run Analysis"))
 		{
-			_splitsChild.Render(StatsData);
-			_graphsChild.Render(StatsData);
+			// Windows and Linux only ever resolve to Unresolved or Resolved, so this only ever substitutes the
+			// splits/graphs children for a status message on macOS - their "game not running" screen (Unresolved,
+			// same as before this branch existed) is untouched.
+			if (gameMemoryService.BlockAddressStatus is BlockAddressStatus.MemoryUnreadable or BlockAddressStatus.BlockNotFound)
+			{
+				ImGui.TextWrapped(Inline.Utf8(gameMemoryServiceWrapper.DescribeUnavailability()));
+			}
+			else
+			{
+				_splitsChild.Render(StatsData);
+				_graphsChild.Render(StatsData);
+			}
 		}
 
 		ImGui.End();

--- a/src/DevilDaggersInfo.Tools/Ui/ReplayEditor/ReplayEditorMenu.cs
+++ b/src/DevilDaggersInfo.Tools/Ui/ReplayEditor/ReplayEditorMenu.cs
@@ -3,6 +3,7 @@ using DevilDaggersInfo.Core.Replay.PostProcessing.ReplaySimulation;
 using DevilDaggersInfo.Tools.Dialogs;
 using DevilDaggersInfo.Tools.EditorFileState;
 using DevilDaggersInfo.Tools.GameMemory;
+using DevilDaggersInfo.Tools.NativeInterface.Services;
 using DevilDaggersInfo.Tools.Ui.Popups;
 using DevilDaggersInfo.Tools.Ui.ReplayEditor.Data;
 using DevilDaggersInfo.Tools.Utils;
@@ -120,7 +121,7 @@ internal sealed class ReplayEditorMenu(
 	{
 		if (!gameMemoryServiceWrapper.Scan() || !gameMemoryService.IsInitialized)
 		{
-			popupManager.ShowError("Could not read replay from game memory. Make sure the game is running.");
+			popupManager.ShowError(DescribeGameMemoryUnavailable("Could not read replay from game memory."));
 			return;
 		}
 
@@ -160,11 +161,23 @@ internal sealed class ReplayEditorMenu(
 	{
 		if (!gameMemoryServiceWrapper.Scan() || !gameMemoryService.IsInitialized)
 		{
-			popupManager.ShowError("Could not inject replay into game memory. Make sure the game is running.");
+			popupManager.ShowError(DescribeGameMemoryUnavailable("Could not inject replay into game memory."));
 			return;
 		}
 
 		gameMemoryService.WriteReplayToMemory(fileStates.Replay.Object.ToLocalReplay().Compile());
+	}
+
+	/// <summary>
+	/// Combines an action-specific prefix with why game memory is unavailable. On macOS, a refusal to read the game's
+	/// memory is not the same problem as the game not running, and telling the user to "make sure the game is running"
+	/// when it is running and the app just was not launched under sudo would send them looking in the wrong place.
+	/// </summary>
+	private string DescribeGameMemoryUnavailable(string actionPrefix)
+	{
+		return gameMemoryService.BlockAddressStatus == BlockAddressStatus.MemoryUnreadable
+			? $"{actionPrefix} {gameMemoryServiceWrapper.DescribeUnavailability()}"
+			: $"{actionPrefix} Make sure the game is running.";
 	}
 
 	public void Close()


### PR DESCRIPTION
Adds macOS (arm64) support, buildable and runnable from source on Apple Silicon.

Source-only: CI is untouched and no macOS artifact is published. `.github/workflows/release.yml` has no changes.

## Shape of the change

Most of this is a third implementation behind interfaces that already exist. `INativeMemoryService`, `INativeWindowingService` and `IPlatformSpecificValues` gain OSX siblings under `NativeInterface/Services/OSX/` and `Platforms/`, and the csproj gains an OSX arm beside the WINDOWS and LINUX ones.

**No new file switches on platform.** `Container.cs`, `Ui/Config/ConfigLayout.cs` and the csproj are the only ones that do, as before.

## The two things that could not look like the other platforms

**Finding the ddstats block.** Windows and Linux read a pointer at an offset the DevilDaggers.info API supplies. There is no API route serving that offset for macOS, so `OSXMemoryService` declares `RequiresMarkerOffset => false` and scans instead, walking readable regions via `mach_vm_region`.

A marker match is not a block — the game's own string literal contains the same bytes — so every candidate is validated with `MainBlock.IsValid`. That is also what stops the `MainBlock` constructor throwing on a buffer whose 32-byte name fields contain no null byte, which on the render loop would be a crash. The scan reads gigabytes and takes seconds, so the resolved address is cached against the pid and an empty scan sets a cooldown; without that the ~300 Hz render loop would scan continuously.

**The `sudo` requirement.** macOS restricts reading another process's memory to root — `task_for_pid` returns `KERN_FAILURE` otherwise, and no entitlement substitutes for that on a locally built unsigned binary. Practice mode's live stats, replay reading and replay injection therefore need the app started with `sudo`. Everything else works without it.

## What this does to Windows and Linux

Nothing, and I've tried to make that checkable rather than asked for on trust.

`BlockAddressStatus` splits what was a boolean into `Unresolved` / `Resolved` / `MemoryUnreadable` / `BlockNotFound`. The last two are produced **only** by the macOS scan path, so the branches that check for them are unreachable on Windows and Linux by construction, and the "game not running" screen on those platforms is unchanged.

Gating the shared UI on the status rather than on `IsInitialized` is deliberate: `IsInitialized` is also false when the game simply is not running, which happens on every platform, so branching on that would have changed Windows and Linux behaviour.

## Smaller notes

- macOS refuses a Core-profile context that is not also forward-compatible, and `glfwCreateWindow` returns null rather than an error when the hint is missing.
- `glDebugMessageCallback` is OpenGL 4.3 / `KHR_debug`, which macOS never exposed, so the `Debug`-only debug context is compiled out there (`#if DEBUG && !OSX`) and untouched elsewhere.
- `AppOperatingSystem` has no macOS member — it ships in the `DevilDaggersInfo.Web.ApiSpec.Tools` package — so the macOS build reports `Linux`. This only affects what the server is told about the submitting client's OS. Adding a member upstream would be the real fix, and I'm happy to follow up if you'd like it.

## Not included

- **Intel Macs.** `osx-x64` is not wired into the csproj and is untested.
- **A fix for the ImGui 1.91→1.92 tooltip regression.** `GraphsChild.AddTooltipText` breaks identically on Windows and Linux and is unrelated to this port, so it's opened separately as #158 rather than buried in a thousand-line port. It's nine lines and independent of this PR — worth taking regardless of what you decide here.

## Verification

Both projects build clean from this branch on macOS 26.6.2 (arm64), .NET SDK 10.0.400:

```
dotnet build src/DevilDaggersInfo.Tools.Engine/DevilDaggersInfo.Tools.Engine.csproj   # 0 errors
dotnet build src/DevilDaggersInfo.Tools/DevilDaggersInfo.Tools.csproj                 # 0 errors, 107 warnings, all pre-existing
```

Against a running game under `sudo`, the scan located the ddstats block at `0x30A0011D0` after reading 624 MB across 1189 memory regions, and live Run Analysis stats rendered correctly.

Two things I'd rather state than have you find:

- **The process aborted shortly after that.** It traced to `GraphsChild.AddTooltipText` leaving a dangling cursor move, which Dear ImGui 1.92 asserts on inside `EndTooltip`; `IM_ASSERT` calls `abort()`. That is shared UI with no `#if` near it, it fires identically on Windows and Linux, and it arrived with 156fd51 (the ImGui.NET → Hexa.NET.ImGui migration), an ancestor of the commit this branch started from. It is not introduced here and is not fixed here — that's #158. Run Analysis on any platform cannot be exercised to completion without it.
- **`PracticeStatsData.Populate` remains an unaudited suspect** for that same abort: it reads a fixed 3600-entry buffer with a loop bounded by `MainBlock.StatsCount`, taken from game memory unchecked. I could not separate it from the ImGui assert with the evidence I have, so I'm flagging it rather than claiming it's clear. It is pre-existing and platform-independent either way.

The Mach bindings were separately proven by targeting the app's own pid, which needs neither root nor the game running: `task_for_pid` → `KERN_SUCCESS`, `mach_vm_region` walked 193 regions / 6344 MB, `mach_vm_read_overwrite` read back a Mach-O header.

`MACOS.md` carries the build steps and the rest of the detail.
